### PR TITLE
Level select is always selectable from the title screen, and record which levels were won

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -218,6 +218,11 @@ function unloadGame() {
 function generateTitleScreen()
 {
 	titleMode=(curlevel>0||curlevelTarget!==null)?1:0;
+	if (!!window.localStorage) {
+		if (localStorage[document.URL+'_levelswon']!==undefined){
+			titleMode = 1;
+		}
+	}
 
 	if (state.levels.length===0) {
 		titleImage=intro_template;
@@ -231,18 +236,18 @@ function generateTitleScreen()
 
 	if (titleMode===0) {
 		if (titleSelection===0) {
-            if (titleSelected) {
-                titleImage = deepClone(titletemplate_firstgo0_selected);		
-            } else {
-                titleImage = deepClone(titletemplate_firstgo0);					
-            }
+			if (titleSelected) {
+				titleImage = deepClone(titletemplate_firstgo0_selected);		
+			} else {
+				titleImage = deepClone(titletemplate_firstgo0);					
+			}
 		} else if (titleSelection===1) {
 			if (titleSelected) {
 				titleImage = deepClone(titletemplate_firstgo1_selected);		
 			} else {
 				titleImage = deepClone(titletemplate_firstgo1);					
 			}						
-        }
+		}
 	} else {
 		if (titleSelection===0) {
 			if (titleSelected) {
@@ -371,9 +376,18 @@ function generateLevelSelectScreen() {
 		var rowIndex=3+2*Math.floor(i/5);
 		var label=""+(point+1);
 		var offset=0;
+		if (!!window.localStorage) {
+			if (localStorage[document.URL+'_levelswon']!==undefined) {
+				var backupStr = localStorage[document.URL+'_levelswon'];
+				var levelsWon = JSON.parse(backupStr);
+				if (levelsWon[pageOffset+i]) {
+					label="*"+label;
+					offset=-1;
+				}
+			}
+		}
 		if (point===curlevelPoint){
-			label="["+label+"]";
-			offset=-1;
+			label=label+"<";
 		}
 		titleImage[rowIndex]=titleImage[rowIndex].slice(0,colIndex+offset)+label+titleImage[rowIndex].slice(colIndex+offset+label.length);
 		if (levelSelectCursor===point){
@@ -2795,6 +2809,9 @@ function nextLevel() {
 			//new game
 			curlevel=0;
 			curlevelTarget=null;
+			if (!!window.localStorage) {
+				localStorage.removeItem(document.URL+'_levelswon');
+			}
 		} 			
 		if (curlevelTarget!==null){			
 			loadLevelFromStateTarget(state,curlevel,curlevelTarget);
@@ -2812,6 +2829,7 @@ function nextLevel() {
 		}
 		if (curlevel<(state.levels.length-1))
 		{			
+			markLevelWon();
 			curlevel++;
 			textMode=false;
 			titleScreen=false;
@@ -2826,9 +2844,9 @@ function nextLevel() {
 		} else {
 			try{
 				if (!!window.localStorage) {
-	
 					localStorage.removeItem(document.URL);
 					localStorage.removeItem(document.URL+'_checkpoint');
+					localStorage.removeItem(document.URL+'_levelswon');
 				}
 			} catch(ex){
 					
@@ -2861,6 +2879,21 @@ function nextLevel() {
 	}
 	canvasResize();	
 	clearInputHistory();
+}
+
+function markLevelWon() {
+	if (!window.localStorage) return;
+
+	var levelsWon = {};
+	if (localStorage[document.URL+'_levelswon']!==undefined){
+		var backupStr = localStorage[document.URL+'_levelswon'];
+		levelsWon = JSON.parse(backupStr);
+	}
+
+	levelsWon[curlevel] = true;
+
+	var backupStr = JSON.stringify(levelsWon);
+	localStorage[document.URL+'_levelswon']=backupStr;
 }
 
 function goToTitleScreen(){

--- a/js/engine.js
+++ b/js/engine.js
@@ -46,8 +46,7 @@ var messagecontainer_template = [
 	".................................."
 ];
 
-var titletemplate_firstgo = [
-	"..................................",
+var titletemplate_firstgo0 = [
 	"..................................",
 	"..................................",
 	"..................................",
@@ -55,6 +54,22 @@ var titletemplate_firstgo = [
 	"..................................",
 	"..........#.start game.#..........",
 	"..................................",
+	"...........level select...........",
+	"..................................",
+	".arrow keys to move...............",
+	".X to action......................",
+	".Z to undo, R to restart..........",
+	".................................."];
+
+var titletemplate_firstgo1 = [
+	"..................................",
+	"..................................",
+	"..................................",
+	"..................................",
+	"..................................",
+	"............start game............",
+	"..................................",
+	".........#.level select.#.........",
 	"..................................",
 	".arrow keys to move...............",
 	".X to action......................",
@@ -107,8 +122,7 @@ var titletemplate_select2 = [
 	".................................."];
 
 
-var titletemplate_firstgo_selected = [
-	"..................................",
+var titletemplate_firstgo0_selected = [
 	"..................................",
 	"..................................",
 	"..................................",
@@ -116,6 +130,22 @@ var titletemplate_firstgo_selected = [
 	"..................................",
 	"###########.start game.###########",
 	"..................................",
+	"...........level select...........",
+	"..................................",
+	".arrow keys to move...............",
+	".X to action......................",
+	".Z to undo, R to restart..........",
+	".................................."];
+
+var titletemplate_firstgo1_selected = [
+	"..................................",
+	"..................................",
+	"..................................",
+	"..................................",
+	"..................................",
+	"............start game............",
+	"..................................",
+	"##########.level select.##########",
 	"..................................",
 	".arrow keys to move...............",
 	".X to action......................",
@@ -200,11 +230,19 @@ function generateTitleScreen()
 	}
 
 	if (titleMode===0) {
-		if (titleSelected) {
-			titleImage = deepClone(titletemplate_firstgo_selected);		
-		} else {
-			titleImage = deepClone(titletemplate_firstgo);					
-		}
+		if (titleSelection===0) {
+            if (titleSelected) {
+                titleImage = deepClone(titletemplate_firstgo0_selected);		
+            } else {
+                titleImage = deepClone(titletemplate_firstgo0);					
+            }
+		} else if (titleSelection===1) {
+			if (titleSelected) {
+				titleImage = deepClone(titletemplate_firstgo1_selected);		
+			} else {
+				titleImage = deepClone(titletemplate_firstgo1);					
+			}						
+        }
 	} else {
 		if (titleSelection===0) {
 			if (titleSelected) {

--- a/js/engine.js
+++ b/js/engine.js
@@ -386,9 +386,6 @@ function generateLevelSelectScreen() {
 				}
 			}
 		}
-		if (point===curlevelPoint){
-			label=label+"<";
-		}
 		titleImage[rowIndex]=titleImage[rowIndex].slice(0,colIndex+offset)+label+titleImage[rowIndex].slice(colIndex+offset+label.length);
 		if (levelSelectCursor===point){
 			label="#";

--- a/js/inputoutput.js
+++ b/js/inputoutput.js
@@ -677,20 +677,6 @@ function checkKey(e,justPressed) {
     			else if (inputdir===1) { levelSelectCursor-=1; }
     			else if (inputdir===2) { levelSelectCursor+=5; }
     			else if (inputdir===3) { levelSelectCursor+=1; }
-                /*
-    			if (inputdir===0 && levelSelectCursor>=5) {
-                    levelSelectCursor-=5;
-                }
-    			else if (inputdir===1) {
-                    levelSelectCursor-=1;
-                }
-    			else if (inputdir===2 && levelSelectCursor<state.level_select_points.length-5) {
-                    levelSelectCursor+=5;
-                }
-    			else if (inputdir===3) {
-                    levelSelectCursor+=1;
-                }
-                */
     			normalizeLevelSelectCursor();
     			generateLevelSelectScreen();
     			redraw();

--- a/js/inputoutput.js
+++ b/js/inputoutput.js
@@ -638,43 +638,29 @@ function checkKey(e,justPressed) {
     	if (state.levels.length===0) {
     		//do nothing
     	} else if (titleScreen) {
-    		if (titleMode===0) {
-    			if (inputdir===4&&justPressed) {
-    				if (titleSelected===false) {    				
-						tryPlayStartGameSound();
-	    				titleSelected=true;
-	    				messageselected=false;
-	    				timer=0;
-	    				quittingTitleScreen=true;
-	    				generateTitleScreen();
-	    				canvasResize();
-	    			}
-    			}
-    		} else {
-    			if (inputdir==4&&justPressed) {
-    				if (titleSelected===false) {    				
-						tryPlayStartGameSound();
-	    				titleSelected=true;
-	    				messageselected=false;
-	    				timer=0;
-	    				quittingTitleScreen=true;
-	    				generateTitleScreen();
-	    				redraw();
-	    			}
-    			} else if (inputdir===0 || inputdir===2) {
-    				var maxTitleSelection = ('enable_level_select' in state.metadata) ? 2 : 1;
-    				if (inputdir===0 && titleSelection > 0) {
-	    				titleSelection--;
-	    				generateTitleScreen();
-	    				redraw();
-	    			} else if (inputdir===2 && titleSelection < maxTitleSelection) {
-	    				titleSelection++;
-
-	    				generateTitleScreen();
-	    				redraw();
-	    			}
-    			}
-    		}
+            if (inputdir==4&&justPressed) {
+                if (titleSelected===false) {    				
+                    tryPlayStartGameSound();
+                    titleSelected=true;
+                    messageselected=false;
+                    timer=0;
+                    quittingTitleScreen=true;
+                    generateTitleScreen();
+                    redraw();
+                }
+            } else if (inputdir===0 || inputdir===2) {
+                var maxTitleSelection = ('enable_level_select' in state.metadata) ? 2 : 1;
+                if (titleMode===0) maxTitleSelection--;
+                if (inputdir===0 && titleSelection > 0) {
+                    titleSelection--;
+                    generateTitleScreen();
+                    redraw();
+                } else if (inputdir===2 && titleSelection < maxTitleSelection) {
+                    titleSelection++;
+                    generateTitleScreen();
+                    redraw();
+                }
+            }
     	} else if (levelSelectScreen) {
     		if (inputdir==4&&justPressed) {
     			if (levelSelectSelected===false) {
@@ -691,6 +677,20 @@ function checkKey(e,justPressed) {
     			else if (inputdir===1) { levelSelectCursor-=1; }
     			else if (inputdir===2) { levelSelectCursor+=5; }
     			else if (inputdir===3) { levelSelectCursor+=1; }
+                /*
+    			if (inputdir===0 && levelSelectCursor>=5) {
+                    levelSelectCursor-=5;
+                }
+    			else if (inputdir===1) {
+                    levelSelectCursor-=1;
+                }
+    			else if (inputdir===2 && levelSelectCursor<state.level_select_points.length-5) {
+                    levelSelectCursor+=5;
+                }
+    			else if (inputdir===3) {
+                    levelSelectCursor+=1;
+                }
+                */
     			normalizeLevelSelectCursor();
     			generateLevelSelectScreen();
     			redraw();
@@ -731,7 +731,7 @@ function update() {
     if (quittingTitleScreen) {
         if (timer/1000>0.3) {
             quittingTitleScreen=false;
-            if (titleSelection===2) {
+            if (titleSelection===2 || (titleMode===0 && titleSelection===1)) {
                 goToLevelSelectScreen();
             } else {
                 nextLevel();

--- a/js/inputoutput.js
+++ b/js/inputoutput.js
@@ -683,10 +683,10 @@ function checkKey(e,justPressed) {
     		}
     	} else {
     		if (inputdir==4&&justPressed) {    				
-				if (unitTesting) {
-					nextLevel();
-					return;
-				} else if (messageselected===false) {
+    				if (unitTesting) {
+    					nextLevel();
+    					return;
+    				} else if (messageselected===false) {
     				messageselected=true;
     				timer=0;
     				quittingMessageScreen=true;


### PR DESCRIPTION
- "level select" is selectable from the title screen, even when there is no "continue" option
- If you have won ANY level, "continue" is now an option on the title screen. (As opposed to the old check of if save data exists).
- Won levels are stored in localStorage[document.URL+'_levelswon'] as a JSON string.
- When you select "new game" from the title screen, your won levels get reset.