### PR TITLE
Level select bugfixes and tweaks

### DIFF
--- a/js/inputoutput.js
+++ b/js/inputoutput.js
@@ -647,6 +647,14 @@ function checkKey(e,justPressed) {
                     quittingTitleScreen=true;
                     generateTitleScreen();
                     redraw();
+
+                    if (titleSelection == 0) {
+                        try {
+                            if (!!window.localStorage) {
+                                localStorage.removeItem(document.URL+'_levelswon');
+                            }
+                        } catch (ex) { }
+                    }
                 }
             } else if (inputdir===0 || inputdir===2) {
                 var maxTitleSelection = ('enable_level_select' in state.metadata) ? 2 : 1;


### PR DESCRIPTION
When trying out the thinky collective game with this, I noticed and fixed these things:

- Add "Esc to return to menu" to menu, if level select is enabled
- Wrap some window.localStorage checks in try-catch blocks, referencing commit 1afe101
- Move markLevelWon() to a more appropriate spot, preventing levels getting marked as won when they weren't supposed to in some cases
- If level select is disabled, don't save levelswon to localStorage
- Pass curlevel through getLevelSelectPointForLevelId before recording level as won - fixes incorrect behavior when the game contains messages.
- Don't reset levels won upon beating the game - since you may want to go back and beat the ones you skipped.

This makes me a little nervous that there will be bugs in the thinky collective game release, but I've tested a bit with that game and with a test game, and things seem okay.

Also, some edge cases I noticed, that may or may not be worth addressing:
- If there are multiple levels between level_select_points, currently the level won marker doesn't work properly - it marks it as won when you beat the first one.
- If there is nothing, or only messages, between level_select_points, it will not get marked as won.
- If the game is updated to add, remove, or reorder levels, then your save progress gets messed up because it's using the old numbers. Maybe level_select_point could have a number or string argument. Or maybe it could somehow detect it's a newer version of the game and reset your save data.